### PR TITLE
feat(bluetooth): add a bluetooth module

### DIFF
--- a/modules/nixos/desktop/bluetooth.nix
+++ b/modules/nixos/desktop/bluetooth.nix
@@ -1,0 +1,30 @@
+{ config
+, lib
+, pkgs
+, ...
+}: {
+  options = {
+    nixosConfig.desktop.bluetooth.enable = lib.options.mkOption {
+      default = false;
+      defaultText = "Enables bluetooth";
+      description = "Enable bluetooth hardware support and config";
+      type = lib.types.bool;
+    };
+  };
+  config =
+    let
+      cfg = config.nixosConfig.desktop.bluetooth;
+    in
+    lib.mkIf cfg.enable {
+      hardware.bluetooth.enable = true;
+
+      # To enable bluetooth experimental features, like the battery level
+      hardware.bluetooth.package = pkgs.bluez5-experimental;
+
+      hardware.bluetooth.settings = {
+        General = {
+          Experimental = true;
+        };
+      };
+    };
+}

--- a/modules/nixos/desktop/default.nix
+++ b/modules/nixos/desktop/default.nix
@@ -3,6 +3,7 @@
 }: {
   imports = [
     ./audio.nix
+    ./bluetooth.nix
     ./fonts.nix
     ./qt.nix
     ./services.nix
@@ -12,7 +13,7 @@
     ./wm/sway.nix
   ];
   config = {
-    # Xorg
+    # Desktop service
     services.xserver = {
       enable = true;
       # Configure keymap in X11

--- a/systems/nixos/default.nix
+++ b/systems/nixos/default.nix
@@ -39,9 +39,12 @@
       enable = true;
       wayland = true;
     };
-    nixosConfig.desktop.sway = {
-      enable = true;
-      nvidia = true;
+    nixosConfig.desktop = {
+      bluetooth.enable = true;
+      sway = {
+        enable = true;
+        nvidia = true;
+      };
     };
 
     networking = {

--- a/systems/nixos/hardware-configuration.nix
+++ b/systems/nixos/hardware-configuration.nix
@@ -72,7 +72,6 @@
     hardware = {
       enableRedistributableFirmware = true;
       cpu.amd.updateMicrocode = true;
-      bluetooth.enable = true;
     };
   };
 }


### PR DESCRIPTION
This module enables bluetooth support in NixOS, adds the options to enable it. It enables the experimental features of bluez5, like the battery level.