### PR TITLE
feat(gpg): use pcscd instead of the integrated ccid to reduce lag

### DIFF
--- a/modules/home-manager/gpg.nix
+++ b/modules/home-manager/gpg.nix
@@ -1,5 +1,6 @@
 # Configure GPG and the GPG agent to use with home-manager
 { config
+, pkgs
 , ...
 }: {
   config = {
@@ -9,6 +10,17 @@
       settings = {
         keyserver = "hkps://keys.openpgp.org";
         use-agent = true;
+      };
+      scdaemonSettings = {
+        # Use the pcsc instead of the integrated ccid
+        # https://wiki.archlinux.org/title/GnuPG#GnuPG_with_pcscd_(PCSC_Lite)
+        disable-ccid = true;
+        pcsc-driver = "${pkgs.pcsclite.out}/lib/libpcsclite.so";
+        card-timeout = "5";
+        pcsc-shared = true;
+        # with pcsc-shared the pin is asked every time, this fixes it
+        # https://dev.gnupg.org/T5436
+        disable-application = "piv";
       };
     };
     services.gpg-agent = {

--- a/modules/nixos/gnupg.nix
+++ b/modules/nixos/gnupg.nix
@@ -1,14 +1,20 @@
+# Configure gpg with pcscd and udev rules
 { pkgs
 , ...
 }: {
   config = {
+    # Gnome key-chain
     services.dbus.packages = [ pkgs.gcr ];
+    # Enable udev rules
     hardware.gpgSmartcards.enable = true;
+    # Packages for the cli
     environment.systemPackages = with pkgs; [
       gnupg
       pinentry
       pinentry.curses
       pinentry.tty
     ];
+    # Enable the pcscd daemon to be used instead of the integrated gnupg ccid, or if the ccid fails.
+    services.pcscd.enable = true;
   };
 }


### PR DESCRIPTION
This configures the gpg-agent scdaemon to use the smart card in shared mode through pcscd. This is an attempt to reduce lag and errors when multiple applications want to access the smart card.