### PR TITLE
feat(plymouth): make the boot quiet to show password prompt

### DIFF
--- a/modules/nixos/bluetooth.nix
+++ b/modules/nixos/bluetooth.nix
@@ -1,10 +1,11 @@
+# Enables the hardware configs for bluetooth and configures bluez service.
 { config
 , lib
 , pkgs
 , ...
 }: {
   options = {
-    nixosConfig.desktop.bluetooth.enable = lib.options.mkOption {
+    nixosConfig.hardware.bluetooth.enable = lib.options.mkOption {
       default = false;
       defaultText = "Enables bluetooth";
       description = "Enable bluetooth hardware support and config";
@@ -13,7 +14,7 @@
   };
   config =
     let
-      cfg = config.nixosConfig.desktop.bluetooth;
+      cfg = config.nixosConfig.hardware.bluetooth;
     in
     lib.mkIf cfg.enable {
       hardware.bluetooth.enable = true;
@@ -21,6 +22,7 @@
       # To enable bluetooth experimental features, like the battery level
       hardware.bluetooth.package = pkgs.bluez5-experimental;
 
+      # Enables the experimental features like battery status for the device.
       hardware.bluetooth.settings = {
         General = {
           Experimental = true;

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -2,6 +2,10 @@
 , hostname
 , ...
 }: {
+  imports = [
+    ./plymouth.nix
+    ./bluetooth.nix
+  ];
   config = {
     networking.hostName = hostname;
 

--- a/modules/nixos/desktop/default.nix
+++ b/modules/nixos/desktop/default.nix
@@ -5,7 +5,6 @@
 }: {
   imports = [
     ./audio.nix
-    ./bluetooth.nix
     ./fonts.nix
     ./qt.nix
     ./services.nix
@@ -31,11 +30,6 @@
       displayManager.gdm.enable = true;
     };
 
-    environment.systemPackages = with pkgs; [
-      # Browser
-      firefox
-      chromium
-    ]
-    ++ import ../../../pkgs/desktop.nix { inherit pkgs lib config; };
+    environment.systemPackages = import ../../../pkgs/desktop.nix { inherit pkgs lib config; };
   };
 }

--- a/modules/nixos/plymouth.nix
+++ b/modules/nixos/plymouth.nix
@@ -1,0 +1,28 @@
+# Enables plymouth with quiet boot configuration
+{ config
+, lib
+, ...
+}:
+let
+  cfg = config.nixosConfig.boot.plymouth;
+in
+{
+  options = {
+    nixosConfig.boot.plymouth.enable = lib.options.mkOption {
+      default = false;
+      defaultText = "Enable plymouth boot splash screen";
+      description = ''
+        Make the plymouth boot splash screen available with the kernel parameters configuration for
+        silent boot.
+      '';
+      type = lib.types.bool;
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    # Enable the plymouth service
+    boot.plymouth.enable = true;
+    # Make the boot quiet (man kernel-command-line), should make the password prompt for the
+    # LUCKS device
+    boot.kernelParams = [ "quiet" ];
+  };
+}

--- a/pkgs/desktop.nix
+++ b/pkgs/desktop.nix
@@ -11,6 +11,10 @@ with pkgs; [
   # Editor
   vscode
 
+  # Browser
+  firefox
+  chromium
+
   # Applications
   libreoffice
   rnote # NOTE: Testing as a xournalpp alternative

--- a/systems/burkstaller/default.nix
+++ b/systems/burkstaller/default.nix
@@ -31,7 +31,6 @@
       nixos-hardware.nixosModules.common-pc-ssd
     ];
   config = {
-    boot.plymouth.enable = true;
     security.tpm2.enable = true;
 
     # Enable desktop system
@@ -40,9 +39,10 @@
       wayland = true;
       gnome.enable = true;
     };
-    nixosConfig.desktop = {
-      bluetooth.enable = true;
-      sway.enable = true;
+    nixosConfig = {
+      boot.plymouth.enable = true;
+      hardware.bluetooth.enable = true;
+      desktop.sway.enable = true;
     };
 
     # Enable docker

--- a/systems/nixos/default.nix
+++ b/systems/nixos/default.nix
@@ -31,20 +31,24 @@
     nixos-hardware.nixosModules.common-pc-laptop-acpi_call
   ];
   config = {
-    boot.plymouth.enable = true;
     security.tpm2.enable = true;
 
     # Enable desktop system
-    systemConfig.desktop = {
-      enable = true;
-      wayland = true;
-      gnome.enable = true;
-    };
-    nixosConfig.desktop = {
-      bluetooth.enable = true;
-      sway = {
+    systemConfig = {
+      desktop = {
         enable = true;
-        nvidia = true;
+        wayland = true;
+        gnome.enable = true;
+      };
+    };
+    nixosConfig = {
+      boot.plymouth.enable = true;
+      hardware.bluetooth.enable = true;
+      desktop = {
+        sway = {
+          enable = true;
+          nvidia = true;
+        };
       };
     };
 


### PR DESCRIPTION
This separates the plymouth module and add options. Sets the kernelParams to ["quiet"] to make the cryptsetup show the password prompt with plymouth.