### PR TITLE
fix(plymouth): boot with systemd initrd in stage 1

### DIFF
--- a/modules/nixos/plymouth.nix
+++ b/modules/nixos/plymouth.nix
@@ -24,5 +24,9 @@ in
     # Make the boot quiet (man kernel-command-line), should make the password prompt for the
     # LUCKS device
     boot.kernelParams = [ "quiet" ];
+
+    # NOTE: This could be buggy and some of the initrd.systemd options are unstable and subject to
+    #       change, but it's needed to start plymouth in stage 1
+    boot.initrd.systemd.enable = true;
   };
 }


### PR DESCRIPTION
This fixes the password prompt not showing.