### PR TITLE
feat(firefox): use the firefox binary package

### DIFF
--- a/pkgs/desktop.nix
+++ b/pkgs/desktop.nix
@@ -12,7 +12,7 @@ with pkgs; [
   vscode
 
   # Browser
-  firefox
+  firefox-bin
   chromium
 
   # Applications


### PR DESCRIPTION
Use the binary package since it has better performance (65 vs 85 on browser bench)