### PR TITLE
fix(gpg): set the pcsc-shared option

### DIFF
--- a/modules/homeManager/gpg.nix
+++ b/modules/homeManager/gpg.nix
@@ -16,7 +16,7 @@
         ## https://wiki.archlinux.org/title/GnuPG#GnuPG_with_pcscd_(PCSC_Lite)
         disable-ccid = true;
         pcsc-driver = "${pkgs.pcsclite.out}/lib/libpcsclite.so";
-        # pcsc-shared = true;
+        pcsc-shared = true;
         ## with pcsc-shared the pin is asked every time, this fixes it
         ## https://dev.gnupg.org/T5436
         # disable-application = "piv";


### PR DESCRIPTION
This will make the YubiKey require the pin every time, but it will reduce the lag when the key is inserted.